### PR TITLE
feat: implementar docker para se conectar com backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20-alpine
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+
+RUN npm install --only=production
+
+COPY . .
+
+EXPOSE 3000
+
+CMD [ "npm", "start" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+    sumus-app:
+        build: .
+        container_name: frontend-sumus
+        ports:
+            - "3000:3000"
+        environment:
+            - PORT=3000
+        networks:
+            - frontend-sumus-network
+
+networks:
+    frontend-sumus-network:
+      external: true


### PR DESCRIPTION
Mudanças simples, mas foram testadas localmente. Com essas mudanças, é somente necessário subir primeiro o backend na sua máquina usando o comando anotado no README (```docker compose --profile dev up --build```), esperar tudo rodar corretamente e logo depois subir o frontend com ```docker compose up``` para os dois se comunicarem via rede docker.